### PR TITLE
3.5.0 update and initial build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - python
     - setuptools_scm
+    - wheel
   run:
     - python
     - importlib-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - hatch-vcs
   run:
     - python
-    - importlib-metadata
+    - importlib-metadata  # [py<38]
     - wcwidth
   run_constrained:
     # Following from conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,15 @@ test:
     - prettytable
 
 about:
-  home: https://github.com/jazzband/prettytable
+  home: https://pypi.org/project/prettytable/
   license_file: COPYING
   license: BSD-3-Clause
-  summary: A simple Python library for easily displaying tabular data in a visually appealing ASCII table format
+  summary: Display tabular data in a visually appealing ASCII table format
+  description: |
+    A simple Python library for easily displaying tabular data in
+    a visually appealing ASCII table format
+  dev_url: https://github.com/jazzband/prettytable
+  doc_url: https://github.com/jazzband/prettytable/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ about:
   home: https://pypi.org/project/prettytable/
   license_file: COPYING
   license: BSD-3-Clause
+  license_family: BSD
   summary: Display tabular data in a visually appealing ASCII table format
   description: |
     A simple Python library for easily displaying tabular data in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,9 @@ requirements:
   host:
     - pip
     - python
-    - setuptools_scm
     - wheel
+    - hatchling
+    - hatch-vcs
   run:
     - python
     - importlib-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - importlib-metadata
     - wcwidth
   run_constrained:
+    # Following from conda-forge
+    # Prevent ptable from interfering with prettytable
     - ptable >=9999
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prettytable" %}
-{% set version = "3.3.0" %}
+{% set version = "3.5.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 118eb54fd2794049b810893653b20952349df6d3bc1764e7facd8a18064fa9b0
+  sha256: 52f682ba4efe29dccb38ff0fe5bac8a23007d0780ff92a8b85af64bc4fc74d72
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,17 @@ source:
   sha256: 52f682ba4efe29dccb38ff0fe5bac8a23007d0780ff92a8b85af64bc4fc74d72
 
 build:
-  noarch: python
+  skip: true  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - setuptools_scm
   run:
-    - python >=3.7
+    - python
     - importlib-metadata
     - wcwidth
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,10 @@ requirements:
     - ptable >=9999
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - prettytable
 


### PR DESCRIPTION
Jira issue: https://anaconda.atlassian.net/browse/PKG-930
Upstream Repo: https://github.com/jazzband/prettytable

`prettytable` -> `ipython-sql`

Forked from conda-forge at 3.3.0, but never built for defaults or added to aggregate. Updating to 3.5.0 and uploading first build.