### PR TITLE
prettytable 3.16.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,27 @@
 {% set name = "prettytable" %}
-{% set version = "3.5.0" %}
-
+{% set version = "3.16.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 52f682ba4efe29dccb38ff0fe5bac8a23007d0780ff92a8b85af64bc4fc74d72
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
     - python
-    - wheel
-    - hatchling
     - hatch-vcs
+    - hatchling >=1.27
   run:
     - python
-    - importlib-metadata  # [py<38]
     - wcwidth
   run_constrained:
     # Following from conda-forge
@@ -32,16 +29,20 @@ requirements:
     - ptable >=9999
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
   imports:
     - prettytable
+    - prettytable.colortable
+    - prettytable.prettytable
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # Cannot invoke upstream tests -> ModuleNotFoundError: No module named 'pytest_lazy_fixtures'
+  requires:
+    - pip
 
 about:
-  home: https://pypi.org/project/prettytable/
-  license_file: COPYING
+  home: https://pypi.org/project/prettytable
+  license_file: LICENSE
   license: BSD-3-Clause
   license_family: BSD
   summary: Display tabular data in a visually appealing ASCII table format


### PR DESCRIPTION
prettytable 3.16.0 

**Destination channel:** Defaults

### Links

- [PKG-9746]
- dev_url:        https://github.com/jazzband/prettytable/tree/3.16.0
- conda_forge:    https://github.com/conda-forge/prettytable-feedstock
- pypi:           https://pypi.org/project/prettytable/3.16.0
- pypi inspector: https://inspector.pypi.io/project/prettytable/3.16.0

### Explanation of changes:

- new version number


[PKG-9746]: https://anaconda.atlassian.net/browse/PKG-9746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ